### PR TITLE
Switch Jinja2 Markup to markupsafe

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+- 0.5.3
+    - Switched to markupsafe as Jinja2's markup function was deprecated
+
 - 0.5.2
     - Project URL updated
     - Use Travis CI for testing

--- a/flask_xcaptcha.py
+++ b/flask_xcaptcha.py
@@ -3,7 +3,7 @@ The new xCaptcha implementation for Flask without Flask-WTF
 """
 
 __NAME__ = "Flask-xCaptcha"
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 __license__ = "MIT"
 __author__ = "Max Levine"
 __copyright__ = "(c) 2020 Max Levine"

--- a/flask_xcaptcha.py
+++ b/flask_xcaptcha.py
@@ -10,7 +10,7 @@ __copyright__ = "(c) 2020 Max Levine"
 
 try:
     from flask import request
-    from jinja2 import Markup
+    import markupsafe as Markup
     import requests
 except ImportError as ex:
     print("Missing dependencies")

--- a/flask_xcaptcha.py
+++ b/flask_xcaptcha.py
@@ -10,7 +10,7 @@ __copyright__ = "(c) 2020 Max Levine"
 
 try:
     from flask import request
-    import markupsafe as Markup
+    import markupsafe
     import requests
 except ImportError as ex:
     print("Missing dependencies")
@@ -56,7 +56,7 @@ class XCaptcha(object):
 
             @app.context_processor
             def get_code():
-                return dict(xcaptcha=Markup(self.get_code()))
+                return dict(xcaptcha=markupsafe.Markup(self.get_code()))
 
         elif site_key is not None:
             self.site_key = site_key


### PR DESCRIPTION
Jinja2 deprecated their "Markup()" function, they are advising now to use markupsafe instead. This pull request makes this change so that flask-xcaptcha will work with new versions of Jinja2.

See https://github.com/pallets/jinja/issues/1438 for some more info.