### PR TITLE
v0.5.4: Correct sourcing of remote_addr

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+- 0.5.4
+    - Correct sourcing of remote_addr. Asyncronous versions of the request object (e.g. from Quart framework) do not have the *environ* attribute. Sourcing remote_addr in this way prevents the need to access environ, and is more correct anyway.
+
 - 0.5.3
     - Markup should be imported from MarkupSafe
 

--- a/flask_xcaptcha.py
+++ b/flask_xcaptcha.py
@@ -3,7 +3,7 @@ The new xCaptcha implementation for Flask without Flask-WTF
 """
 
 __NAME__ = "Flask-xCaptcha"
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 __license__ = "MIT"
 __author__ = "Max Levine"
 __copyright__ = "(c) 2022 Max Levine"

--- a/flask_xcaptcha.py
+++ b/flask_xcaptcha.py
@@ -98,9 +98,10 @@ class XCaptcha(object):
             data = {
                 "secret": self.secret_key,
                 "response": response or request.form.get('{}-response'.format(self.div_class)),
-                "remoteip": remote_ip or request.environ.get('REMOTE_ADDR')
+                "remoteip": remote_ip or request.remote_addr
             }
 
             r = requests.get(self.verify_url, params=data)
             return r.json()["success"] if r.status_code == 200 else False
         return True
+


### PR DESCRIPTION
Asyncronous versions of the request object (e.g. from Quart framework) do not have the *environ* attribute. Sourcing remote_addr in this way prevents the need to access environ, and is more correct anyway.